### PR TITLE
Autoload events hub

### DIFF
--- a/characters/base_character/base_character.gd
+++ b/characters/base_character/base_character.gd
@@ -72,4 +72,4 @@ func show_money_earned(money : float, percent : float = 1) -> void:
 	add_child(label)
 	label.position = money_label_offset
 	label.display("$" + str(round(money)), percent)
-	emit_signal("score", money)
+	EventHub.emit_signal("add_money", money)

--- a/characters/cat/Cat.tscn
+++ b/characters/cat/Cat.tscn
@@ -224,14 +224,14 @@ tracks/1/loop_wrap = true
 tracks/1/imported = false
 tracks/1/enabled = true
 tracks/1/keys = {
-"times": PoolRealArray( 0.7, 1.2 ),
+"times": PoolRealArray( 0.7, 1 ),
 "transitions": PoolRealArray( 1, 1 ),
 "values": [ {
 "args": [  ],
 "method": "_on_jump_start"
 }, {
 "args": [  ],
-"method": "_on_end_of_path"
+"method": "_on_jump_end"
 } ]
 }
 

--- a/game_utils/EventHub.gd
+++ b/game_utils/EventHub.gd
@@ -2,3 +2,4 @@ extends Node
 
 signal occupy_object
 signal leave_object
+signal add_money

--- a/game_utils/EventHub.gd
+++ b/game_utils/EventHub.gd
@@ -1,0 +1,4 @@
+extends Node
+
+signal occupy_object
+signal leave_object

--- a/levels/base_level/Laundry Scene.gd
+++ b/levels/base_level/Laundry Scene.gd
@@ -8,7 +8,7 @@ var counters
 func _ready() -> void:
 	counters = $Objects/Counters.get_children()
 	initialize_level()
-		
+	
 func initialize_level() -> void:
 	for counter in counters:
 		counter.connect("click", $Objects/Player, "_on_Interactable_click")
@@ -64,11 +64,13 @@ func _on_restart_day() -> void:
 
 func _on_Cat_mischief() -> void:
 	# Give cat location of counter with laundry
-	var location = Vector2.ZERO
+	var location := Vector2.ZERO
+	var id : int
 	
 	# TODO: better way of selecting location
 	# (Like randomly choosing an occupied counter or having preference for clean laundry)
 	for counter in counters:
 		if counter.laundry_available:
-			location = counter.get_jump_launch_position()	
-	cat.manage_mischief(location)
+			location = counter.get_jump_launch_position()
+			id = counter.get_instance_id()	
+	cat.manage_mischief(location, id)

--- a/levels/base_level/Laundry Scene.tscn
+++ b/levels/base_level/Laundry Scene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=53 format=2]
+[gd_scene load_steps=52 format=2]
 
 [ext_resource path="res://levels/base_level/Laundry Scene.gd" type="Script" id=1]
 [ext_resource path="res://levels/base_level/tile floor.png" type="Texture" id=2]
@@ -14,7 +14,6 @@
 [ext_resource path="res://font/Awake/Awake.ttf" type="DynamicFontData" id=12]
 [ext_resource path="res://levels/base_level/HUD.gd" type="Script" id=13]
 [ext_resource path="res://characters/player/transfer.wav" type="AudioStream" id=14]
-[ext_resource path="res://levels/base_level/Events.gd" type="Script" id=15]
 [ext_resource path="res://icons/KawaiiIcons_NoBG015.png" type="Texture" id=16]
 [ext_resource path="res://icons/KawaiiIcons_NoBG004.png" type="Texture" id=17]
 [ext_resource path="res://icons/KawaiiIcons_NoBG010.png" type="Texture" id=18]
@@ -820,22 +819,24 @@ font_data = ExtResource( 12 )
 
 [sub_resource type="GDScript" id=20]
 script/source = "extends Label
-var score : int = 0
+#TODO: save money in more permanent way, for multiple days of play
+var money : int = 0 
 
 func _ready():
-	format_score()
+	format_money()
+	EventHub.connect(\"add_money\", self, \"_on_add_money\")
 	
 func reset():
-	score = 0
-	format_score()
+	money = 0
+	format_money()
 
-func format_score():
-	set_text(\"$\" + str(score))
+func format_money():
+	set_text(\"$\" + str(money))
 
-func _on_Events_score_update(addition : float):
+func _on_add_money(addition : float):
 # warning-ignore:narrowing_conversion
-	score += round(addition)
-	format_score()
+	money += round(addition)
+	format_money()
 "
 
 [sub_resource type="DynamicFont" id=21]
@@ -1067,9 +1068,6 @@ __meta__ = {
 stream = ExtResource( 14 )
 bus = "soundfx"
 
-[node name="Events" type="Node" parent="."]
-script = ExtResource( 15 )
-
 [node name="BackgroundMusic" parent="." instance=ExtResource( 9 )]
 
 [node name="RestartDay" type="Button" parent="."]
@@ -1117,12 +1115,10 @@ __meta__ = {
 [connection signal="timeout" from="Spawner/CustomerTimer" to="Spawner" method="_on_Timer_timeout"]
 [connection signal="timeout" from="Spawner/WaitTimer" to="Spawner" method="_on_WaitTimer_timeout"]
 [connection signal="mischief_wanted" from="Objects/Cat" to="." method="_on_Cat_mischief"]
-[connection signal="score" from="Objects/Cat" to="Events" method="update_score"]
 [connection signal="almost_closing" from="Clock" to="Spawner" method="_on_Clock_almost_closing"]
 [connection signal="day_over" from="Clock" to="." method="_on_day_over"]
 [connection signal="new_hour" from="Clock" to="Spawner" method="_on_Clock_new_hour"]
 [connection signal="timeout" from="Clock/MinuteTimer" to="Clock" method="_on_MinuteTimer_timeout"]
 [connection signal="new_game" from="HUD" to="." method="_on_HUD_new_game"]
 [connection signal="pressed" from="HUD/Button" to="." method="_on_new_game"]
-[connection signal="score_update" from="Events" to="MoneyLabel" method="_on_Events_score_update"]
 [connection signal="restart_button_pressed" from="RestartDay" to="." method="_on_restart_day"]

--- a/levels/base_level/SpawnPoint.gd
+++ b/levels/base_level/SpawnPoint.gd
@@ -31,7 +31,6 @@ func create_customer() -> KinematicBody2D:
 	# Connect the appropriate signals
 	customer.connect("leaving", self, "handle_leaving")
 	customer.connect("returning", self, "handle_entering")
-	customer.connect("score", get_parent().get_node("Events"), "update_score")
 	customer.get_node("Bumper").connect("click", player, "_on_Interactable_click")
 	customer.add_to_group("dropping_off")
 	

--- a/models/counter/Counter.gd
+++ b/models/counter/Counter.gd
@@ -3,7 +3,9 @@ extends "res://models/laundry_holder/LaundryHolder.gd"
 func _ready() -> void:
 	._ready()
 	offset = Vector2(-5, -25)
-
+	EventHub.connect("occupy_object", self, "be_occupied")
+	EventHub.connect("leave_object", self, "be_free")
+	
 func disallowed_action() -> void:
 	$AnimationPlayer.play("shake")
 
@@ -13,11 +15,9 @@ func get_jump_launch_position() -> Vector2:
 func get_sleep_position() -> Vector2:
 	return $SleepLocation.global_position
 	
-func cat_shedding() -> void:
-	interactable = false
+func be_occupied(id : int) -> void:
+	if id == get_instance_id(): interactable = false
 
-func _on_Interactable_body_exited(body : PhysicsBody2D) -> void:
-	# Cat only sleeps on counters 
-	if body.get_name() == "Cat":
-		interactable = true
+func be_free(id : int) -> void:
+	if id == get_instance_id(): interactable = true
 

--- a/models/counter/Counter.tscn
+++ b/models/counter/Counter.tscn
@@ -22,7 +22,6 @@ tracks/0/keys = {
 
 [node name="Counter" groups=[
 "InteractableObjects",
-"sheddable",
 ] instance=ExtResource( 1 )]
 collision_mask = 5
 script = ExtResource( 2 )

--- a/project.godot
+++ b/project.godot
@@ -19,8 +19,13 @@ config/name="Laundry Simulator"
 run/main_scene="res://levels/base_level/Laundry Scene.tscn"
 config/icon="res://icon.png"
 
+[autoload]
+
+EventHub="*res://game_utils/EventHub.gd"
+
 [debug]
 
+gdscript/warnings/unused_signal=false
 gdscript/warnings/return_value_discarded=false
 
 [display]


### PR DESCRIPTION
Added autoload/singleton "EventHub" to manage cat occupation of counters. This makes it much more flexible if the cat should occupy other objects as well. Currently the object is "occupied" as soon as the cat starts sleeping (invoking the comfy cat rule), and is "free" when the cat stands back up.

In addition to changing cat occupation logic, I removed the old "Events" node and replaced functionality with the new singleton.
Looser coupling with player and interactables with the new hub is still a todo.